### PR TITLE
Shorten commands to orgs and repos

### DIFF
--- a/GHVS/Program.cs
+++ b/GHVS/Program.cs
@@ -115,7 +115,7 @@ namespace GHVS
         }
     }
 
-    [Command(Description = "Show visible organizations (requires 'read:org' scope)")]
+    [Command("orgs", Description = "Show visible organizations (requires 'read:org' scope)")]
     class OrganizationsCommand : GitHubCommandBase
     {
         protected override async Task OnExecute(CommandLineApplication app)
@@ -145,7 +145,7 @@ namespace GHVS
         }
     }
 
-    [Command(Description = "List repositories")]
+    [Command("repos", Description = "List repositories")]
     class RepositoriesCommand : GitHubCommandBase
     {
         protected override async Task OnExecute(CommandLineApplication app)


### PR DESCRIPTION
Shorten from `organizations` to `orgs` and `repositories` to `repos`.