### PR TITLE
If single arg starts with "https://" use open-url

### DIFF
--- a/GHVS/Program.cs
+++ b/GHVS/Program.cs
@@ -41,6 +41,12 @@ namespace GHVS
                 args = args.Prepend("open").Append(editor).ToArray();
             }
 
+            // If single arg starts with "https://" then implicitly use open-url
+            if (args.Length == 1 && args[0] is string url && url.StartsWith("https://"))
+            {
+                args = args.Prepend("open-url").ToArray();
+            }
+
             return CommandLineApplication.ExecuteAsync<Program>(args);
         }
 


### PR DESCRIPTION
If command line contains a single argument that starts with `https://`, implicitly use the `open-url` command.

Fixes #32