### PR TITLE
Add set-token command

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-    - uses: aarnott/nbgv@v0.3
+    - uses: aarnott/nbgv@v0.4.0
       with:
         setAllVars: true
     - run: echo "NBGV_SemVer2 $NBGV_SemVer2"


### PR DESCRIPTION
- What this PR does

Add `token-set` sub-command that can set the token used by GitHub for Visual Studio. It can be used like this:

```
ghvs set-token --secret-store ghfvs <PAT>
```

- Full instructions

1. Create a PAT with the [following](https://github.com/github/VisualStudio/blob/824bab4ab2c3d8f6787cf38ff5ff9d4e9df00e98/src/GitHub.Api/ApiClientConfiguration.cs#L43) scopes: "user", "repo", "gist", "write:public_key", "read:org", "workflow"
You can use this link https://github.com/settings/tokens
![image](https://user-images.githubusercontent.com/11719160/100374454-37da7c00-3004-11eb-8182-20d9245ea115.png)
2. Install the `ghvs` tool
`dotnet tool install -g ghvs --version 1.0.113-g022796defc`
3. Set the GitHub for Visual Studio token
`ghvs set-token --secret-store ghfvs <PAT>`
4. Open Visual Studio and `File > Open > Open from GitHub...`

If everything wend to plan, you should see a list of repositories.